### PR TITLE
fix issue on initial load with no active server

### DIFF
--- a/dedi-mgmt.js
+++ b/dedi-mgmt.js
@@ -13,7 +13,7 @@ const DediApp = Vue.createApp({
 	},
 	data() {
 		return {
-			activeTab: -1,
+			activeTab: undefined,
 			pods: [
 				{
 					podId: 1,


### PR DESCRIPTION
This is a change since the active tab isn't using an index but rather an identifier. Defaulting to `undefined` make the initial load work and not have the initial error from vue. The error came from the detail view trying to render, since `-1` is truthy in JS. Since there wasn't a selected server it was failing on rendering the name for `dedi.serverName`.